### PR TITLE
Find the most specific address

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -71,6 +71,13 @@ function cleanDescription(desc: string): string {
     description = description.replace(/\n/g, "\n\n");
     return description;
 }
+function sortBySizeAsc(addressRanges: Array<AddressRange>): Array<AddressRange> {
+  return addressRanges.sort((ar1, ar2) => {
+    if (ar1.addr.size < ar2.addr.size) return -1;
+    if (ar1.addr.size > ar2.addr.size) return 1;
+    return 0;
+  })
+}
 
 
 // this method is called when your extension is activated
@@ -79,10 +86,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
     // Use the console to output diagnostic information (console.log) and errors (console.error)
     // This line of code will only be executed once when your extension is activated
-    let ramMap: Array<AddressRange> = await getMap('smwram');
-    let romMap: Array<AddressRange> = await getMap('smwrom');
-    let regsMap: Array<AddressRange> = await getMap('smwregs');
-    let hijacksMap: Array<AddressRange> = await getMap('smwhijack');
+    let ramMap: Array<AddressRange> = sortBySizeAsc(await getMap('smwram'));
+    let romMap: Array<AddressRange> = sortBySizeAsc(await getMap('smwrom'));
+    let regsMap: Array<AddressRange> = sortBySizeAsc(await getMap('smwregs'));
+    let hijacksMap: Array<AddressRange> = sortBySizeAsc(await getMap('smwhijack'));
     const sidebarProvider = new SidebarProvider(context.extensionUri, ramMap, romMap);
     console.log('Congratulations, your extension "smwmaplens" is now active!');
     context.subscriptions.push(


### PR DESCRIPTION
When looking up for an address, instead of finding the one that begins first, find the one with the smallest size, which is usually the most specific.

For instance, when looking up for `$7FAB10`, what we currently get is
```
Empty RAM which is entirely untouched.
This area is used by many SMW hacking tools and patches, so hacked ROMs are likely to use some of the addresses found here.
```
but what we usually want is
```
Custom sprite table used by Pixi.
It holds the extra bits of a sprite.
```

I opted for sorting the address ranges directly by size, instead of performing the sorting on lookup, for performance reasons (otherwise we would have to sort `ramMap` and such on every lookup, which is quite expensive given their sizes).

I added the additional function `sortBySizeAsc` instead of putting the sorting inside `getMap`, because maybe the hijacks map should not be sorted (I sorted it anyway).